### PR TITLE
Refactor simplify and reproject modules, rename "extent" to "geometry"

### DIFF
--- a/src/raster_footprint/__init__.py
+++ b/src/raster_footprint/__init__.py
@@ -1,7 +1,7 @@
 from .densify import (
     densify_by_distance,
     densify_by_factor,
-    densify_extent,
+    densify_geometry,
     densify_multipolygon,
     densify_polygon,
 )
@@ -11,9 +11,9 @@ from .footprint import (
     footprint_from_mask,
     footprint_from_rasterio_reader,
 )
-from .mask import create_mask, get_mask_extent
-from .reproject import reproject_extent, reproject_multipolygon, reproject_polygon
-from .simplify import simplify_extent, simplify_multipolygon, simplify_polygon
+from .mask import create_mask, get_mask_geometry
+from .reproject import reproject_geometry
+from .simplify import simplify_geometry
 
 __all__ = [
     "footprint_from_data",
@@ -21,16 +21,12 @@ __all__ = [
     "footprint_from_mask",
     "footprint_from_rasterio_reader",
     "create_mask",
-    "get_mask_extent",
+    "get_mask_geometry",
     "densify_by_distance",
     "densify_by_factor",
     "densify_polygon",
     "densify_multipolygon",
-    "densify_extent",
-    "reproject_polygon",
-    "reproject_multipolygon",
-    "reproject_extent",
-    "simplify_polygon",
-    "simplify_multipolygon",
-    "simplify_extent",
+    "densify_geometry",
+    "reproject_geometry",
+    "simplify_geometry",
 ]

--- a/src/raster_footprint/densify.py
+++ b/src/raster_footprint/densify.py
@@ -149,8 +149,8 @@ def densify_multipolygon(
     return MultiPolygon(densified_polygons)
 
 
-def densify_extent(
-    extent: T,
+def densify_geometry(
+    geometry: T,
     *,
     factor: Optional[int] = None,
     distance: Optional[float] = None,
@@ -158,7 +158,7 @@ def densify_extent(
     """Adds vertices to a polygon or each polygon in a multipolygon.
 
     Args:
-        extent (T): The polygon or multipolygon to densify.
+        geometry (T): The polygon or multipolygon to densify.
         factor (Optional[int]): The factor by which to increase the number of
             polygon vertices, e.g., a ``factor`` of 2 will double the number of
             vertices. Mutually exclusive with ``distance``. Defaults to ``None``.
@@ -170,9 +170,9 @@ def densify_extent(
     Returns:
         T: The densified polygon or multipolygon.
     """
-    if isinstance(extent, Polygon):
-        return densify_polygon(extent, factor=factor, distance=distance)
-    elif isinstance(extent, MultiPolygon):
-        return densify_multipolygon(extent, factor=factor, distance=distance)
+    if isinstance(geometry, Polygon):
+        return densify_polygon(geometry, factor=factor, distance=distance)
+    elif isinstance(geometry, MultiPolygon):
+        return densify_multipolygon(geometry, factor=factor, distance=distance)
     else:
-        raise TypeError("extent must be a Polygon or MultiPolygon")
+        raise TypeError("geometry must be a Polygon or MultiPolygon")

--- a/src/raster_footprint/reproject.py
+++ b/src/raster_footprint/reproject.py
@@ -1,8 +1,8 @@
-from itertools import groupby
 from typing import Optional, TypeVar
 
 from rasterio.crs import CRS
 from rasterio.warp import transform_geom
+from shapely.constructive import remove_repeated_points
 from shapely.geometry import MultiPolygon, Polygon, shape
 
 DEFAULT_PRECISION = 7
@@ -10,82 +10,32 @@ DEFAULT_PRECISION = 7
 T = TypeVar("T", Polygon, MultiPolygon)
 
 
-def reproject_polygon(
-    polygon: Polygon, crs: CRS, *, precision: Optional[int] = DEFAULT_PRECISION
-) -> Polygon:
-    """Reprojects a polygon to WGS84 (EPSG:4326).
-
-    Reprojected polygon vertex coordinates are rounded to ``precision``.
-    Duplicate points caused by rounding are removed.
-
-    Args:
-        polygon (Polygon): The polygon to reproject.
-        crs (CRS): A :class:`rasterio.crs.CRS` object defining the
-            coordinate reference system of the given ``polygon``.
-        precision (Optional[int]): The number of decimal places to include in
-            the reprojected polygon vertex coordinates. Defaults to 7.
-
-    Returns:
-        Polygon: The reprojected polygon.
-    """
-    polygon = shape(transform_geom(crs, "EPSG:4326", polygon, precision=precision))
-    shell = [k for k, _ in groupby(polygon.exterior.coords)]
-    holes = [[k for k, _ in groupby(interior.coords)] for interior in polygon.interiors]
-    return Polygon(shell=shell, holes=holes)
-
-
-def reproject_multipolygon(
-    multipolygon: MultiPolygon,
-    crs: CRS,
-    *,
-    precision: Optional[int] = DEFAULT_PRECISION,
-) -> MultiPolygon:
-    """Reprojects each polygon in a multipolygon to WGS84 (EPSG:4326).
-
-    Reprojected polygon vertex coordinates are rounded to ``precision``.
-    Duplicate points caused by rounding are removed.
-
-    Args:
-        multipolygon (MultiPolygon): The multipolygon to reproject.
-        crs (CRS): A :class:`rasterio.crs.CRS` object defining the
-            coordinate reference system of the given ``multipolygon``.
-        precision (Optional[int]): The number of decimal places to include in
-            the final polygon vertex coordinates. Defaults to 7.
-
-    Returns:
-        MultiPolygon: The reprojected multipolygon.
-    """
-    reprojected_polygons = [
-        reproject_polygon(polygon, crs, precision=precision)
-        for polygon in multipolygon.geoms
-    ]
-    return MultiPolygon(reprojected_polygons)
-
-
-def reproject_extent(
-    extent: T,
-    crs: CRS,
+def reproject_geometry(
+    source_crs: CRS,
+    destination_crs: CRS,
+    geometry: T,
     *,
     precision: Optional[int] = DEFAULT_PRECISION,
 ) -> T:
-    """Reprojects a polygon or multipolygon to WGS84 (EPSG:4326).
+    """Reprojects a polygon or multipolygon from a source CRS to a destination CRS.
 
     Reprojected polygon vertex coordinates are rounded to ``precision``.
     Duplicate points caused by rounding are removed.
 
     Args:
-        extent (T): The polygon or multipolygon to reproject.
-        crs (CRS): A :class:`rasterio.crs.CRS` object defining the
-            coordinate reference system of the given ``extent``.
+        source_crs (CRS): A :class:`rasterio.crs.CRS` object defining the
+            coordinate reference system of the input ``geometry``.
+        destination_crs (CRS): A :class:`rasterio.crs.CRS` object defining the
+            coordinate reference system of the output geometry.
+        geometry (T): The polygon or multipolygon to reproject.
         precision (Optional[int]): The number of decimal places to include in
             the final polygon vertex coordinates. Defaults to 7.
 
     Returns:
         T: The reprojected polygon or multipolygon.
     """
-    if isinstance(extent, Polygon):
-        return reproject_polygon(extent, crs, precision=precision)
-    elif isinstance(extent, MultiPolygon):
-        return reproject_multipolygon(extent, crs, precision=precision)
-    else:
-        raise TypeError("extent must be a Polygon or MultiPolygon")
+    return remove_repeated_points(
+        shape(
+            transform_geom(source_crs, destination_crs, geometry, precision=precision)
+        )
+    )

--- a/src/raster_footprint/simplify.py
+++ b/src/raster_footprint/simplify.py
@@ -5,58 +5,13 @@ from shapely.geometry import MultiPolygon, Polygon
 T = TypeVar("T", Polygon, MultiPolygon)
 
 
-def simplify_polygon(polygon: Polygon, *, tolerance: Optional[float] = None) -> Polygon:
-    """Reduces the number of vertices in the given ``polygon`` such that the
-    outline of the simplified polygon is no further away from any of the
-    original polygon vertices than ``tolerance``.
-
-    Note that ``tolerance`` must be given in units of geographic decimal degrees.
-
-    Args:
-        polygon (Polygon): The polygon to simplify.
-        tolerance (Optional[float]): The maximum distance between the original
-            polygon vertices and the simplified polygon. Unit is geographic
-            decimal degrees. Defaults to ``None``.
-
-    Returns:
-        Polygon: The simplified polygon.
-    """
-    if tolerance is not None:
-        return polygon.simplify(tolerance=tolerance, preserve_topology=False)
-    return polygon
-
-
-def simplify_multipolygon(
-    multipolygon: MultiPolygon, *, tolerance: Optional[float] = None
-) -> MultiPolygon:
-    """Reduces the number of vertices in each polygon of the given
-    ``multipolygon`` such that the outline of each simplified polygon is no
-    further away from any of its original vertices than ``tolerance``.
-
-    Note that ``tolerance`` must be given in units of geographic decimal degrees.
-
-    Args:
-        multipolygon (MultiPolygon): The multipolygon to simplify.
-        tolerance (Optional[float]): The maximum distance between original
-            polygon vertices and the simplified polygon. Unit is geographic
-            decimal degrees. Defaults to ``None``.
-
-    Returns:
-        MultiPolygon: The simplified multipolygon.
-    """
-    simplified_polygons = [
-        simplify_polygon(polygon, tolerance=tolerance) for polygon in multipolygon.geoms
-    ]
-    return MultiPolygon(simplified_polygons)
-
-
-def simplify_extent(extent: T, *, tolerance: Optional[float] = None) -> T:
+def simplify_geometry(geometry: T, *, tolerance: Optional[float] = None) -> T:
     """Reduces the number of vertices in a polygon or each polygon of a
     multipolygon such that the outline of each simplified polygon is no
     further away from any of its original vertices than ``tolerance``.
 
     Args:
-        extent (T): The polygon or multipolygon to simplify.
+        geometry (T): The polygon or multipolygon to simplify.
         tolerance (Optional[float]): The maximum distance between original
             polygon vertices and the simplified polygon. Unit is geographic
             decimal degrees. Defaults to ``None``.
@@ -64,9 +19,6 @@ def simplify_extent(extent: T, *, tolerance: Optional[float] = None) -> T:
     Returns:
         T: The simplified polygon or multipolygon.
     """
-    if isinstance(extent, Polygon):
-        return simplify_polygon(extent, tolerance=tolerance)
-    elif isinstance(extent, MultiPolygon):
-        return simplify_multipolygon(extent, tolerance=tolerance)
-    else:
-        raise TypeError("extent must be a Polygon or MultiPolygon")
+    if tolerance is not None:
+        return geometry.simplify(tolerance=tolerance, preserve_topology=False)
+    return geometry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,18 +14,18 @@ def read_geojson(name: str) -> Dict[str, Any]:
     return data
 
 
-def check_winding(extent: Union[Polygon, MultiPolygon, Dict[str, Any]]) -> None:
-    if isinstance(extent, dict):
-        extent = shape(extent)
+def check_winding(geometry: Union[Polygon, MultiPolygon, Dict[str, Any]]) -> None:
+    if isinstance(geometry, dict):
+        geometry = shape(geometry)
 
-    if isinstance(extent, Polygon):
-        assert extent.exterior.is_ccw
-        for interior in extent.interiors:
+    if isinstance(geometry, Polygon):
+        assert geometry.exterior.is_ccw
+        for interior in geometry.interiors:
             assert not interior.is_ccw
-    elif isinstance(extent, MultiPolygon):
-        for polygon in extent.geoms:
+    elif isinstance(geometry, MultiPolygon):
+        for polygon in geometry.geoms:
             assert polygon.exterior.is_ccw
             for interior in polygon.interiors:
                 assert not interior.is_ccw
     else:
-        raise TypeError("`extent` must be a Polygon, MultiPolygon, or GeoJSON dict")
+        raise TypeError("'geometry' must be a Polygon, MultiPolygon, or GeoJSON dict")

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -13,11 +13,10 @@ import numpy as np
 import pytest
 import rasterio
 from numpy import typing as npt
+from raster_footprint.footprint import footprint_from_data, footprint_from_href
 from rasterio import Affine
 from rasterio.crs import CRS
 from shapely.geometry import shape
-
-from raster_footprint.footprint import footprint_from_data, footprint_from_href
 
 from .conftest import TEST_DATA_DIRECTORY, check_winding, read_geojson
 
@@ -52,7 +51,7 @@ def test_no_footprint() -> None:
     data_array = np.zeros((3, 3), dtype=np.uint8)
     crs = "EPSG:4326"
     transform = Affine(1, 0, 0, 0, -1, 0)
-    assert footprint_from_data(data_array, crs, transform, nodata=0) is None
+    assert footprint_from_data(data_array, transform, crs, nodata=0) is None
 
 
 def test_modis(modis_href_data_crs_transform: HrefDataCrsTransform) -> None:
@@ -63,7 +62,7 @@ def test_modis(modis_href_data_crs_transform: HrefDataCrsTransform) -> None:
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
-    data_footprint = footprint_from_data(data_array, crs, transform, nodata=32767)
+    data_footprint = footprint_from_data(data_array, transform, crs, nodata=32767)
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
 
@@ -76,7 +75,7 @@ def test_modis_with_nodata(modis_href_data_crs_transform: HrefDataCrsTransform) 
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
-    data_footprint = footprint_from_data(data_array, crs, transform)
+    data_footprint = footprint_from_data(data_array, transform, crs)
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
 
@@ -90,7 +89,7 @@ def test_modis_precision(modis_href_data_crs_transform: HrefDataCrsTransform) ->
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, crs, transform, nodata=32767, precision=1
+        data_array, transform, crs, nodata=32767, precision=1
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -107,7 +106,7 @@ def test_modis_densify_factor(
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, crs, transform, nodata=32767, densify_factor=2
+        data_array, transform, crs, nodata=32767, densify_factor=2
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -124,7 +123,7 @@ def test_modis_densify_distance(
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, crs, transform, nodata=32767, densify_distance=100000
+        data_array, transform, crs, nodata=32767, densify_distance=100000
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -141,7 +140,7 @@ def test_modis_simplify_tolerance(
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, crs, transform, nodata=32767, simplify_tolerance=0.05
+        data_array, transform, crs, nodata=32767, simplify_tolerance=0.05
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -163,8 +162,8 @@ def test_modis_densify_distance_and_simplify_tolerance(
 
     data_footprint = footprint_from_data(
         data_array,
-        crs,
         transform,
+        crs,
         nodata=32767,
         densify_distance=100000,
         simplify_tolerance=0.01,
@@ -182,7 +181,7 @@ def test_modis_convex_hull(modis_href_data_crs_transform: HrefDataCrsTransform) 
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, crs, transform, nodata=32767, convex_hull=True
+        data_array, transform, crs, nodata=32767, convex_hull=True
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -197,7 +196,7 @@ def test_modis_no_holes(modis_href_data_crs_transform: HrefDataCrsTransform) -> 
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, crs, transform, nodata=32767, holes=False
+        data_array, transform, crs, nodata=32767, holes=False
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -5,7 +5,7 @@ from rasterio import Affine
 from shapely.geometry import shape
 
 from raster_footprint import create_mask
-from raster_footprint.mask import get_mask_extent
+from raster_footprint.mask import get_mask_geometry
 
 from .conftest import read_geojson
 
@@ -89,59 +89,61 @@ def test_create_mask_3d_array() -> None:
     assert np.array_equal(mask, expected)
 
 
-def test_extent_concave_shell(concave_shell: npt.NDArray[np.uint8]) -> None:
-    extent = get_mask_extent(concave_shell, transform=TRANSFORM)
+def test_geometry_concave_shell(concave_shell: npt.NDArray[np.uint8]) -> None:
+    geometry = get_mask_geometry(concave_shell, transform=TRANSFORM)
     expected = read_geojson("concave-shell")
-    assert shape(extent).normalize() == shape(expected).normalize()
+    assert shape(geometry).normalize() == shape(expected).normalize()
 
 
-def test_extent_convex_hull_of_concave_shell(
+def test_geometry_convex_hull_of_concave_shell(
     concave_shell: npt.NDArray[np.uint8],
 ) -> None:
-    extent = get_mask_extent(concave_shell, transform=TRANSFORM, convex_hull=True)
+    geometry = get_mask_geometry(concave_shell, transform=TRANSFORM, convex_hull=True)
     expected = read_geojson("convex-hull-of-concave-shell")
-    assert shape(extent).normalize() == shape(expected).normalize()
+    assert shape(geometry).normalize() == shape(expected).normalize()
 
 
-def test_extent_two_concave_shells(
+def test_geometry_two_concave_shells(
     two_concave_shells: npt.NDArray[np.uint8],
 ) -> None:
-    extent = get_mask_extent(two_concave_shells, transform=TRANSFORM)
+    geometry = get_mask_geometry(two_concave_shells, transform=TRANSFORM)
     expected = read_geojson("two-concave-shells")
-    assert shape(extent).normalize() == shape(expected).normalize()
+    assert shape(geometry).normalize() == shape(expected).normalize()
 
 
-def test_extent_convex_hull_of_two_concave_shells(
+def test_geometry_convex_hull_of_two_concave_shells(
     two_concave_shells: npt.NDArray[np.uint8],
 ) -> None:
-    extent = get_mask_extent(two_concave_shells, transform=TRANSFORM, convex_hull=True)
+    geometry = get_mask_geometry(
+        two_concave_shells, transform=TRANSFORM, convex_hull=True
+    )
     expected = read_geojson("convex-hull-of-two-concave-shells")
-    assert shape(extent).normalize() == shape(expected).normalize()
+    assert shape(geometry).normalize() == shape(expected).normalize()
 
 
-def test_extent_two_concave_shells_with_holes(
+def test_geometry_two_concave_shells_with_holes(
     two_concave_shells_with_holes: npt.NDArray[np.uint8],
 ) -> None:
-    extent = get_mask_extent(two_concave_shells_with_holes, transform=TRANSFORM)
+    geometry = get_mask_geometry(two_concave_shells_with_holes, transform=TRANSFORM)
     expected = read_geojson("two-concave-shells-with-holes")
-    assert shape(extent).normalize() == shape(expected).normalize()
+    assert shape(geometry).normalize() == shape(expected).normalize()
 
 
-def test_extent_convex_hull_of_two_concave_shells_with_holes(
+def test_geometry_convex_hull_of_two_concave_shells_with_holes(
     two_concave_shells_with_holes: npt.NDArray[np.uint8],
 ) -> None:
-    extent = get_mask_extent(
+    geometry = get_mask_geometry(
         two_concave_shells_with_holes, transform=TRANSFORM, convex_hull=True
     )
     expected = read_geojson("convex-hull-of-two-concave-shells")
-    assert shape(extent).normalize() == shape(expected).normalize()
+    assert shape(geometry).normalize() == shape(expected).normalize()
 
 
-def test_extent_two_concave_shells_with_holes_filled(
+def test_geometry_two_concave_shells_with_holes_filled(
     two_concave_shells_with_holes: npt.NDArray[np.uint8],
 ) -> None:
-    extent = get_mask_extent(
+    geometry = get_mask_geometry(
         two_concave_shells_with_holes, transform=TRANSFORM, holes=False
     )
     expected = read_geojson("two-concave-shells")
-    assert shape(extent).normalize() == shape(expected).normalize()
+    assert shape(geometry).normalize() == shape(expected).normalize()

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -1,14 +1,12 @@
-import pytest
-from shapely.geometry import Point, shape
-
-from raster_footprint import reproject_extent
+from raster_footprint import reproject_geometry
+from shapely.geometry import shape
 
 from .conftest import check_winding, read_geojson
 
 
-def test_epsg_4326_is_noop() -> None:
+def test_epsg_noop() -> None:
     polygon = shape(read_geojson("concave-shell.json"))
-    reprojected = reproject_extent(polygon, 4326)
+    reprojected = reproject_geometry(4326, 4326, polygon)
     check_winding(reprojected)
     assert reprojected.normalize() == polygon.normalize()
 
@@ -17,7 +15,7 @@ def test_epsg_utm_32361() -> None:
     multi_polygon = shape(
         read_geojson("two-concave-shells-each-with-two-holes-epsg-32631.json")
     )
-    reprojected = reproject_extent(multi_polygon, 32631, precision=5)
+    reprojected = reproject_geometry(32631, 4326, multi_polygon, precision=5)
     expected = shape(read_geojson("two-concave-shells-each-with-two-holes.json"))
     check_winding(reprojected)
     assert reprojected.normalize() == expected.normalize()
@@ -28,7 +26,7 @@ def test_wkt_sinusoidal() -> None:
     multi_polygon = shape(
         read_geojson("two-concave-shells-each-with-two-holes-wkt-sinusoidal.json")
     )
-    reprojected = reproject_extent(multi_polygon, wkt, precision=5)
+    reprojected = reproject_geometry(wkt, 4326, multi_polygon, precision=5)
     expected = shape(read_geojson("two-concave-shells-each-with-two-holes.json"))
     check_winding(reprojected)
     assert reprojected.normalize() == expected.normalize()
@@ -37,7 +35,7 @@ def test_wkt_sinusoidal() -> None:
 def test_remove_duplicate_points() -> None:
     duplicates = shape(read_geojson("concave-shell-with-duplicate-points.json"))
     deduplicated = shape(read_geojson("concave-shell.json"))
-    reprojected = reproject_extent(duplicates, 4326)
+    reprojected = reproject_geometry(4326, 4326, duplicates)
     check_winding(reprojected)
     assert reprojected.normalize() == deduplicated.normalize()
 
@@ -45,21 +43,16 @@ def test_remove_duplicate_points() -> None:
 def test_precision() -> None:
     polygon = shape(read_geojson("concave-shell-dithered.json"))
 
-    reprojected = reproject_extent(polygon, 4326, precision=3)
+    reprojected = reproject_geometry(4326, 4326, polygon, precision=3)
     check_winding(reprojected)
     for coord in reprojected.exterior.coords:
         for value in coord:
             assert len(str(value).split(".")[1]) == 3
             assert str(value).endswith("3")
 
-    reprojected = reproject_extent(polygon, 4326, precision=5)
+    reprojected = reproject_geometry(4326, 4326, polygon, precision=5)
     check_winding(reprojected)
     for coord in reprojected.exterior.coords:
         for value in coord:
             assert len(str(value).split(".")[1]) == 5
             assert str(value).endswith("6")
-
-
-def test_not_polygon_or_multi_polygon_fails() -> None:
-    with pytest.raises(TypeError):
-        reproject_extent(Point(0, 0), 4326)

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,7 +1,5 @@
-import pytest
-from shapely.geometry import Point, shape
-
-from raster_footprint import simplify_extent
+from raster_footprint import simplify_geometry
+from shapely.geometry import shape
 
 from .conftest import check_winding, read_geojson
 
@@ -9,7 +7,7 @@ from .conftest import check_winding, read_geojson
 def test_simplify_polygon() -> None:
     polygon = shape(read_geojson("concave-shell.json"))
     assert len(polygon.exterior.coords) == 13
-    simplified = simplify_extent(polygon, tolerance=1.1)
+    simplified = simplify_geometry(polygon, tolerance=1.1)
     expected = shape(read_geojson("convex-hull-of-concave-shell.json"))
     check_winding(simplified)
     assert simplified.normalize() == expected.normalize()
@@ -19,19 +17,19 @@ def test_simplify_polygon_with_holes() -> None:
     polygon = shape(read_geojson("concave-shell-with-two-holes.json"))
 
     # small tolerance retains holes
-    simplified = simplify_extent(polygon, tolerance=0.8)
+    simplified = simplify_geometry(polygon, tolerance=0.8)
     expected = shape(read_geojson("concave-shell-with-two-holes-simplified_0.8.json"))
     check_winding(simplified)
     assert simplified.normalize() == expected.normalize()
 
     # large tolerance removes holes
-    simplified = simplify_extent(polygon, tolerance=1.1)
+    simplified = simplify_geometry(polygon, tolerance=1.1)
     expected = shape(read_geojson("convex-hull-of-concave-shell.json"))
     check_winding(simplified)
     assert simplified.normalize() == expected.normalize()
 
     # very large tolerance eliminates polygon
-    simplified = simplify_extent(polygon, tolerance=10)
+    simplified = simplify_geometry(polygon, tolerance=10)
     assert simplified.is_empty
 
 
@@ -39,7 +37,7 @@ def test_simplify_multi_polygon_with_holes() -> None:
     multi_polygon = shape(read_geojson("two-concave-shells-each-with-two-holes.json"))
 
     # small tolerance simplifies shells, retains holes
-    simplified = simplify_extent(multi_polygon, tolerance=0.8)
+    simplified = simplify_geometry(multi_polygon, tolerance=0.8)
     expected = shape(
         read_geojson("two-concave-shells-each-with-two-holes-simplified_0.8.json")
     )
@@ -47,7 +45,7 @@ def test_simplify_multi_polygon_with_holes() -> None:
     assert simplified.normalize() == expected.normalize()
 
     # large tolerance simplifes shells, removes holes
-    simplified = simplify_extent(multi_polygon, tolerance=1.1)
+    simplified = simplify_geometry(multi_polygon, tolerance=1.1)
     expected = shape(
         read_geojson("two-concave-shells-each-with-two-holes-simplified_1.1.json")
     )
@@ -55,10 +53,5 @@ def test_simplify_multi_polygon_with_holes() -> None:
     assert simplified.normalize() == expected.normalize()
 
     # very large tolerance eliminates all polygons
-    simplified = simplify_extent(multi_polygon, tolerance=10)
+    simplified = simplify_geometry(multi_polygon, tolerance=10)
     assert simplified.is_empty
-
-
-def test_not_polygon_or_multi_polygon_fails() -> None:
-    with pytest.raises(TypeError):
-        simplify_extent(Point(0, 0))


### PR DESCRIPTION
## Related issues and pull requests

- Closes #13 
- Closes #8 (I think we're done with bulk variable renames for now)


## Description

- Refactors the simplify and reproject modules to single functions.
- Adds ability to reproject to any CRS, not just EPSG:4326 (WGS84)
- Renames "extent" to "geometry"


## Checklist

- [ ] Add tests
- [ ] Add docs
- [ ] Update CHANGELOG