### PR TITLE
Change position of the geometry argument in the `reproject_geometry` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Move `geometry` argument to first position in `reproject_geometry` ([#24](https://github.com/pjhartzell/raster-footprint/pull/24))
+
 ## [0.1.0] - 2023-08-13
 
 Initial release.

--- a/src/raster_footprint/footprint.py
+++ b/src/raster_footprint/footprint.py
@@ -82,7 +82,7 @@ def footprint_from_mask(
         geometry, factor=densify_factor, distance=densify_distance
     )
     reprojected = reproject_geometry(
-        source_crs, destination_crs, densified, precision=precision
+        densified, source_crs, destination_crs, precision=precision
     )
     simplified = simplify_geometry(reprojected, tolerance=simplify_tolerance)
 

--- a/src/raster_footprint/reproject.py
+++ b/src/raster_footprint/reproject.py
@@ -11,9 +11,9 @@ T = TypeVar("T", Polygon, MultiPolygon)
 
 
 def reproject_geometry(
+    geometry: T,
     source_crs: CRS,
     destination_crs: CRS,
-    geometry: T,
     *,
     precision: Optional[int] = DEFAULT_PRECISION,
 ) -> T:
@@ -23,11 +23,11 @@ def reproject_geometry(
     Duplicate points caused by rounding are removed.
 
     Args:
+        geometry (T): The polygon or multipolygon to reproject.
         source_crs (CRS): A :class:`rasterio.crs.CRS` object defining the
             coordinate reference system of the input ``geometry``.
         destination_crs (CRS): A :class:`rasterio.crs.CRS` object defining the
             coordinate reference system of the output geometry.
-        geometry (T): The polygon or multipolygon to reproject.
         precision (Optional[int]): The number of decimal places to include in
             the final polygon vertex coordinates. Defaults to 7.
 

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -6,7 +6,7 @@ from .conftest import check_winding, read_geojson
 
 def test_epsg_noop() -> None:
     polygon = shape(read_geojson("concave-shell.json"))
-    reprojected = reproject_geometry(4326, 4326, polygon)
+    reprojected = reproject_geometry(polygon, 4326, 4326)
     check_winding(reprojected)
     assert reprojected.normalize() == polygon.normalize()
 
@@ -15,7 +15,7 @@ def test_epsg_utm_32361() -> None:
     multi_polygon = shape(
         read_geojson("two-concave-shells-each-with-two-holes-epsg-32631.json")
     )
-    reprojected = reproject_geometry(32631, 4326, multi_polygon, precision=5)
+    reprojected = reproject_geometry(multi_polygon, 32631, 4326, precision=5)
     expected = shape(read_geojson("two-concave-shells-each-with-two-holes.json"))
     check_winding(reprojected)
     assert reprojected.normalize() == expected.normalize()
@@ -26,7 +26,7 @@ def test_wkt_sinusoidal() -> None:
     multi_polygon = shape(
         read_geojson("two-concave-shells-each-with-two-holes-wkt-sinusoidal.json")
     )
-    reprojected = reproject_geometry(wkt, 4326, multi_polygon, precision=5)
+    reprojected = reproject_geometry(multi_polygon, wkt, 4326, precision=5)
     expected = shape(read_geojson("two-concave-shells-each-with-two-holes.json"))
     check_winding(reprojected)
     assert reprojected.normalize() == expected.normalize()
@@ -35,7 +35,7 @@ def test_wkt_sinusoidal() -> None:
 def test_remove_duplicate_points() -> None:
     duplicates = shape(read_geojson("concave-shell-with-duplicate-points.json"))
     deduplicated = shape(read_geojson("concave-shell.json"))
-    reprojected = reproject_geometry(4326, 4326, duplicates)
+    reprojected = reproject_geometry(duplicates, 4326, 4326)
     check_winding(reprojected)
     assert reprojected.normalize() == deduplicated.normalize()
 
@@ -43,14 +43,14 @@ def test_remove_duplicate_points() -> None:
 def test_precision() -> None:
     polygon = shape(read_geojson("concave-shell-dithered.json"))
 
-    reprojected = reproject_geometry(4326, 4326, polygon, precision=3)
+    reprojected = reproject_geometry(polygon, 4326, 4326, precision=3)
     check_winding(reprojected)
     for coord in reprojected.exterior.coords:
         for value in coord:
             assert len(str(value).split(".")[1]) == 3
             assert str(value).endswith("3")
 
-    reprojected = reproject_geometry(4326, 4326, polygon, precision=5)
+    reprojected = reproject_geometry(polygon, 4326, 4326, precision=5)
     check_winding(reprojected)
     for coord in reprojected.exterior.coords:
         for value in coord:


### PR DESCRIPTION
## Related issues and pull requests

- Closes #23 

## Description

Moves the `geometry` argument to the first position in `reproject_geometry` for consistency with the other functions in the densify-reproject-simplify sequence.

## Checklist

- [ ] Add tests
- [ ] Add docs
- [x] Update CHANGELOG