### PR TITLE
Add a precision option to the densify functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a `precision` option to the densify functions ([#25](https://github.com/pjhartzell/raster-footprint/issues/25))
+
 ### Changed
 
-- Move `geometry` argument to first position in `reproject_geometry` ([#24](https://github.com/pjhartzell/raster-footprint/pull/24))
+- Moved `geometry` argument to first position in `reproject_geometry` ([#24](https://github.com/pjhartzell/raster-footprint/pull/24))
 
 ## [0.1.0] - 2023-08-13
 

--- a/src/raster_footprint/constants.py
+++ b/src/raster_footprint/constants.py
@@ -1,0 +1,8 @@
+from typing import TypeVar
+
+from shapely.geometry.multipolygon import MultiPolygon
+from shapely.geometry.polygon import Polygon
+
+T = TypeVar("T", Polygon, MultiPolygon)
+
+DEFAULT_PRECISION = 7

--- a/src/raster_footprint/footprint.py
+++ b/src/raster_footprint/footprint.py
@@ -8,9 +8,10 @@ from rasterio.crs import CRS
 from rasterio.io import DatasetReader
 from shapely.geometry import mapping
 
+from .constants import DEFAULT_PRECISION
 from .densify import densify_geometry
 from .mask import create_mask, get_mask_geometry
-from .reproject import DEFAULT_PRECISION, reproject_geometry
+from .reproject import reproject_geometry
 from .simplify import simplify_geometry
 
 

--- a/src/raster_footprint/reproject.py
+++ b/src/raster_footprint/reproject.py
@@ -1,13 +1,11 @@
-from typing import Optional, TypeVar
+from typing import Optional
 
 from rasterio.crs import CRS
 from rasterio.warp import transform_geom
 from shapely.constructive import remove_repeated_points
-from shapely.geometry import MultiPolygon, Polygon, shape
+from shapely.geometry import shape
 
-DEFAULT_PRECISION = 7
-
-T = TypeVar("T", Polygon, MultiPolygon)
+from .constants import DEFAULT_PRECISION, T
 
 
 def reproject_geometry(

--- a/src/raster_footprint/simplify.py
+++ b/src/raster_footprint/simplify.py
@@ -1,8 +1,6 @@
-from typing import Optional, TypeVar
+from typing import Optional
 
-from shapely.geometry import MultiPolygon, Polygon
-
-T = TypeVar("T", Polygon, MultiPolygon)
+from .constants import T
 
 
 def simplify_geometry(geometry: T, *, tolerance: Optional[float] = None) -> T:


### PR DESCRIPTION
## Related issues and pull requests

- Closes #22 

## Description

- Adds a `precision` option to the densify functions
- new `constants.py` file to hold some broadly used constants

## Checklist

- [x] Add tests
- [ ] Add docs
- [x] Update CHANGELOG