### PR TITLE
Change holes default to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
 
-- Added a `precision` option to the densify functions ([#25](https://github.com/pjhartzell/raster-footprint/issues/25))
+- Added a `precision` option to the densify functions
+  ([#25](https://github.com/pjhartzell/raster-footprint/issues/25))
 
 ### Changed
 
-- Moved `geometry` argument to first position in `reproject_geometry` ([#24](https://github.com/pjhartzell/raster-footprint/pull/24))
+- Changed default behavior in mask and footprint creation to not include holes
+  ([#26](https://github.com/pjhartzell/raster-footprint/pull/26))
+- Moved `geometry` argument to first position in `reproject_geometry`
+  ([#24](https://github.com/pjhartzell/raster-footprint/pull/24))
 
 ## [0.1.0] - 2023-08-13
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@
 raster-footprint
 ================
 
-A Python package for creating GeoJSON_ geometries that bound valid data in a geospatial
+A Python package for creating GeoJSON_ geometries that bound valid data in geospatial
 rasters.
 
 

--- a/src/raster_footprint/footprint.py
+++ b/src/raster_footprint/footprint.py
@@ -26,7 +26,7 @@ def footprint_from_mask(
     densify_distance: Optional[float] = None,
     simplify_tolerance: Optional[float] = None,
     convex_hull: bool = False,
-    holes: bool = True,
+    holes: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Produces a GeoJSON dictionary containing a polygon or multipolygon geometry
     surrounding valid data locations in the given ``mask`` array.
@@ -66,7 +66,7 @@ def footprint_from_mask(
             polygons. The convex hull is applied prior to densification and
             simplification. Defaults to False.
         holes (bool): Whether to include holes in the created polygons. Has
-            no effect if ``convex_hull`` is True. Defaults to True.
+            no effect if ``convex_hull`` is True. Defaults to False.
 
     Returns:
         Optional[Dict[str, Any]]: A GeoJSON dictionary containing the
@@ -102,7 +102,7 @@ def footprint_from_data(
     densify_distance: Optional[float] = None,
     simplify_tolerance: Optional[float] = None,
     convex_hull: bool = False,
-    holes: bool = True,
+    holes: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Produces a GeoJSON dictionary containing a polygon or multipolygon
     surrounding valid data locations in the given ``data`` array.
@@ -137,7 +137,7 @@ def footprint_from_data(
             polygons. The convex hull is applied prior to densification and
             simplification. Defaults to False.
         holes (bool): Whether to include holes in the created polygons. Has
-            no effect if ``convex_hull`` is True. Defaults to True.
+            no effect if ``convex_hull`` is True. Defaults to False.
 
     Returns:
         Optional[Dict[str, Any]]: A GeoJSON dictionary containing the
@@ -168,7 +168,7 @@ def footprint_from_href(
     densify_distance: Optional[float] = None,
     simplify_tolerance: Optional[float] = None,
     convex_hull: bool = False,
-    holes: bool = True,
+    holes: bool = False,
     bands: Optional[List[int]] = None,
     with_nodata: bool = False,
 ) -> Optional[Dict[str, Any]]:
@@ -207,7 +207,7 @@ def footprint_from_href(
             polygons. The convex hull is applied prior to densification and
             simplification. Defaults to False.
         holes (bool): Whether to include holes in the created polygons. Has
-            no effect if ``convex_hull`` is True. Defaults to True.
+            no effect if ``convex_hull`` is True. Defaults to False.
         with_nodata (bool): If True, a footprint for the entire raster,
             including nodata pixels, is returned. Defaults to False.
         bands (List[int]): The bands to use to compute the footprint.
@@ -245,7 +245,7 @@ def footprint_from_rasterio_reader(
     densify_distance: Optional[float] = None,
     simplify_tolerance: Optional[float] = None,
     convex_hull: bool = False,
-    holes: bool = True,
+    holes: bool = False,
     bands: Optional[List[int]] = None,
     with_nodata: bool = False,
 ) -> Optional[Dict[str, Any]]:
@@ -282,7 +282,7 @@ def footprint_from_rasterio_reader(
             polygons. The convex hull is applied prior to densification and
             simplification. Defaults to False.
         holes (bool): Whether to include holes in the created polygons. Has
-            no effect if ``convex_hull`` is True. Defaults to True.
+            no effect if ``convex_hull`` is True. Defaults to False.
         with_nodata (bool): If True, a footprint for the entire raster,
             including nodata pixels, is returned. Defaults to False.
         bands (List[int]): The bands to use to compute the footprint.

--- a/src/raster_footprint/mask.py
+++ b/src/raster_footprint/mask.py
@@ -49,7 +49,7 @@ def get_mask_geometry(
     *,
     transform: Affine = Affine(1, 0, 0, 0, 1, 0),
     convex_hull: bool = False,
-    holes: bool = True,
+    holes: bool = False,
 ) -> Optional[Union[Polygon, MultiPolygon]]:
     """Creates a polygon or multipolygon surrounding valid data pixels.
 

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -58,11 +58,13 @@ def test_modis(modis_href_data_crs_transform: HrefDataCrsTransform) -> None:
     href, data_array, crs, transform = modis_href_data_crs_transform
     expected = read_geojson("modis.json")
 
-    href_footprint = footprint_from_href(href)
+    href_footprint = footprint_from_href(href, holes=True)
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
-    data_footprint = footprint_from_data(data_array, transform, crs, nodata=32767)
+    data_footprint = footprint_from_data(
+        data_array, transform, crs, nodata=32767, holes=True
+    )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
 
@@ -84,12 +86,12 @@ def test_modis_precision(modis_href_data_crs_transform: HrefDataCrsTransform) ->
     href, data_array, crs, transform = modis_href_data_crs_transform
     expected = read_geojson("modis-precision-1.json")
 
-    href_footprint = footprint_from_href(href, precision=1)
+    href_footprint = footprint_from_href(href, precision=1, holes=True)
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, transform, crs, nodata=32767, precision=1
+        data_array, transform, crs, nodata=32767, precision=1, holes=True
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -101,12 +103,12 @@ def test_modis_densify_factor(
     href, data_array, crs, transform = modis_href_data_crs_transform
     expected = read_geojson("modis-densify_factor-2.json")
 
-    href_footprint = footprint_from_href(href, densify_factor=2)
+    href_footprint = footprint_from_href(href, densify_factor=2, holes=True)
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, transform, crs, nodata=32767, densify_factor=2
+        data_array, transform, crs, nodata=32767, densify_factor=2, holes=True
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -118,12 +120,12 @@ def test_modis_densify_distance(
     href, data_array, crs, transform = modis_href_data_crs_transform
     expected = read_geojson("modis-densify_distance-100000.json")
 
-    href_footprint = footprint_from_href(href, densify_distance=100000)
+    href_footprint = footprint_from_href(href, densify_distance=100000, holes=True)
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, transform, crs, nodata=32767, densify_distance=100000
+        data_array, transform, crs, nodata=32767, densify_distance=100000, holes=True
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -135,12 +137,12 @@ def test_modis_simplify_tolerance(
     href, data_array, crs, transform = modis_href_data_crs_transform
     expected = read_geojson("modis-simplify_tolerance-0.05.json")
 
-    href_footprint = footprint_from_href(href, simplify_tolerance=0.05)
+    href_footprint = footprint_from_href(href, simplify_tolerance=0.05, holes=True)
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
     data_footprint = footprint_from_data(
-        data_array, transform, crs, nodata=32767, simplify_tolerance=0.05
+        data_array, transform, crs, nodata=32767, simplify_tolerance=0.05, holes=True
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -155,7 +157,7 @@ def test_modis_densify_distance_and_simplify_tolerance(
     )
 
     href_footprint = footprint_from_href(
-        href, densify_distance=100000, simplify_tolerance=0.01
+        href, densify_distance=100000, simplify_tolerance=0.01, holes=True
     )
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
@@ -167,6 +169,7 @@ def test_modis_densify_distance_and_simplify_tolerance(
         nodata=32767,
         densify_distance=100000,
         simplify_tolerance=0.01,
+        holes=True,
     )
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
@@ -191,13 +194,11 @@ def test_modis_no_holes(modis_href_data_crs_transform: HrefDataCrsTransform) -> 
     href, data_array, crs, transform = modis_href_data_crs_transform
     expected = read_geojson("modis-no_holes.json")
 
-    href_footprint = footprint_from_href(href, holes=False)
+    href_footprint = footprint_from_href(href)
     check_winding(href_footprint)
     assert shape(href_footprint).normalize() == shape(expected).normalize()
 
-    data_footprint = footprint_from_data(
-        data_array, transform, crs, nodata=32767, holes=False
-    )
+    data_footprint = footprint_from_data(data_array, transform, crs, nodata=32767)
     check_winding(data_footprint)
     assert shape(data_footprint).normalize() == shape(expected).normalize()
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,11 +1,10 @@
 import numpy as np
 import numpy.typing as npt
 import pytest
-from rasterio import Affine
-from shapely.geometry import shape
-
 from raster_footprint import create_mask
 from raster_footprint.mask import get_mask_geometry
+from rasterio import Affine
+from shapely.geometry import shape
 
 from .conftest import read_geojson
 
@@ -124,7 +123,9 @@ def test_geometry_convex_hull_of_two_concave_shells(
 def test_geometry_two_concave_shells_with_holes(
     two_concave_shells_with_holes: npt.NDArray[np.uint8],
 ) -> None:
-    geometry = get_mask_geometry(two_concave_shells_with_holes, transform=TRANSFORM)
+    geometry = get_mask_geometry(
+        two_concave_shells_with_holes, transform=TRANSFORM, holes=True
+    )
     expected = read_geojson("two-concave-shells-with-holes")
     assert shape(geometry).normalize() == shape(expected).normalize()
 
@@ -142,8 +143,6 @@ def test_geometry_convex_hull_of_two_concave_shells_with_holes(
 def test_geometry_two_concave_shells_with_holes_filled(
     two_concave_shells_with_holes: npt.NDArray[np.uint8],
 ) -> None:
-    geometry = get_mask_geometry(
-        two_concave_shells_with_holes, transform=TRANSFORM, holes=False
-    )
+    geometry = get_mask_geometry(two_concave_shells_with_holes, transform=TRANSFORM)
     expected = read_geojson("two-concave-shells")
     assert shape(geometry).normalize() == shape(expected).normalize()


### PR DESCRIPTION
## Description

An opinionated, breaking change that flips the default behavior for hole creation in footprints and masks from `True` to `False`.  Defining the external spatial limits of valid data locations only - as opposed to the external limits plus internal holes - is a more natural interpretation of a data "footprint", in my opinion.

## Checklist

- [ ] Add tests
- [ ] Add docs
- [x] Update CHANGELOG